### PR TITLE
Version 1.1.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## Changes in 1.1.0
+
+* Use scipy-notebook:2021-11-01 as the base image, to ensure compatibility
+  with chart version 1.2.0 and hub image version 1.2.0.
+
 ## Changes in 1.0.9
 
 * Update base scipy-notebook image from 2021-09-27 to 2022-04-25

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 ## Changes in 1.1.0
 
 * Use scipy-notebook:2021-11-01 as the base image, to ensure compatibility
-  with chart version 1.2.0 and hub image version 1.2.0.
+  with chart version 1.2.0 and hub image version 1.2.0
+* Add voila package
 
 ## Changes in 1.0.9
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ using the quay.io build service and made available in the Docker repository
 `quay.io/bcdev/avl-user`. The quay.io web page for the Docker repository is at
 <https://quay.io/repository/bcdev/avl-user>.
 
+## Running the user image directly
+
 While the AVL user image is intended for use within with AVL Jupyter Hub
 deployment, it can also be run directly using docker, for example for testing
 before deployment to a cluster:
@@ -30,3 +32,15 @@ cluster deployment. In particular, when running the user image locally with
 Docker, no environment variables are initialized with credentials for external
 service access (e.g. geoDB), so if needed these must be set by the user (e.g.
 with `os.environ['GEODB_AUTH_CLIENT_ID'] = '<my-client-id>'`, etc.).
+
+## jupyterhub package versioning
+
+The Jupyter hub process and single-user notebook server communicate using
+an API provided by the `jupyterhub` package. For reliable operation, the hub and
+user images in a deployment must use the same minor version of this package. You
+can check the `jupyterhub` version in the user image with the following command:
+
+```bash
+docker run -it --rm quay.io/bcdev/avl-user:<tag> \
+    python3 -c 'import jupyterhub; print(jupyterhub.__version__)'
+```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,18 +4,23 @@
 # credentials cause Docker-Hub-based builds to fail on quay.io; see
 # https://issues.redhat.com/browse/PROJQUAY-1299?_sscc=t for details.
 
-# Source: https://github.com/jupyter/docker-stacks/tree/master/scipy-notebook
-FROM quay.io/bcdev/scipy-notebook:2022-04-25
+# Base image source:
+# https://github.com/jupyter/docker-stacks/tree/master/scipy-notebook .
+# The version is carefully selected to match the base-notebook version
+# used for the jupyterhub/k8s-singleuser-sample:1.2.0 image, which is the
+# default user image in the z2jh 1.2.0 Helm chart. This should ensure
+# compatibility with the corresponding hub image and with the chart itself.
+FROM quay.io/bcdev/scipy-notebook:2021-11-01
 
 LABEL maintainer="pontus.lurcock@brockmann-consult.de"
 LABEL name="avl-user-env"
-LABEL version="1.0.9"
+LABEL version="1.1.0.dev0"
 LABEL description="User environment for AVL JupyterHub deployment"
 
 USER root
 
-# Upgrade some packages to fix known vulnerabilities in the base image,
-# and install additional packages.
+# Upgrade some packages to fix known vulnerabilities in the base image
+# and/or install additional packages.
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update --yes && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,11 +6,11 @@
 
 # Base image source:
 # https://github.com/jupyter/docker-stacks/tree/master/scipy-notebook .
-# The version is carefully selected to match the base-notebook version
-# used for the jupyterhub/k8s-singleuser-sample:1.2.0 image, which is the
-# default user image in the z2jh 1.2.0 Helm chart. This should ensure
-# compatibility with the corresponding hub image and with the chart itself.
-FROM quay.io/bcdev/scipy-notebook:2021-11-01
+# The version is carefully selected to provide version 1.5.0 of the jupyterhub
+# package, as used in the jupyterhub/k8s-hub:1.2.0 image specified in the
+# default values of the z2jh 1.2.0 Helm chart. This should ensure compatibility
+# with the corresponding AVL hub image and with the chart itself.
+FROM quay.io/bcdev/scipy-notebook:2021-11-20
 
 LABEL maintainer="pontus.lurcock@brockmann-consult.de"
 LABEL name="avl-user-env"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ FROM quay.io/bcdev/scipy-notebook:2021-11-20
 
 LABEL maintainer="pontus.lurcock@brockmann-consult.de"
 LABEL name="avl-user-env"
-LABEL version="1.1.0.dev0"
+LABEL version="1.1.0.dev1"
 LABEL description="User environment for AVL JupyterHub deployment"
 
 USER root
@@ -57,6 +57,7 @@ RUN mamba install --yes \
     'rasterstats==0.15.0' \
     'rioxarray==0.10.2' \
     'sentinelhub==3.3.2' \
+    'voila==0.3.5' \
     'xarray==2022.3.0' \
     'xcube==0.10.2' \
     'xcube-cci==0.9.5' \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,7 +14,7 @@ FROM quay.io/bcdev/scipy-notebook:2021-11-20
 
 LABEL maintainer="pontus.lurcock@brockmann-consult.de"
 LABEL name="avl-user-env"
-LABEL version="1.1.0.dev1"
+LABEL version="1.1.0"
 LABEL description="User environment for AVL JupyterHub deployment"
 
 USER root


### PR DESCRIPTION
## Changes in 1.1.0

* Use scipy-notebook:2021-11-01 as the base image, to ensure compatibility
  with chart version 1.2.0 and hub image version 1.2.0
* Add voila package
